### PR TITLE
Remove toc from pages

### DIFF
--- a/docs/_docs/dev/api.md
+++ b/docs/_docs/dev/api.md
@@ -5,7 +5,6 @@ category: "Contributor Hub"
 catsub: "APIs"
 last_updated: 24 Nov 2019
 summary: "Our documentation and API center for the technology that makes Wysc possible. Integrate Wysc into your product!"
-toc: true
 redirect_from:
   - dev
   - docs/about/dev/1

--- a/docs/_docs/dev/search.md
+++ b/docs/_docs/dev/search.md
@@ -4,7 +4,6 @@ title:  "Search API"
 category: "Contributor Hub"
 catsub: "APIs"
 summary: "The Search API helps make discovering information across Wysc easier, from blog posts to documentation."
-toc: true
 ---
 
 ### Wysc Discord


### PR DESCRIPTION
jekyll_toc doesn't seem to run on GitHub Pages, so am removing toc: true from pages. Maybe will look to remove jekyll_toc completely in the future.